### PR TITLE
Fix/stackby filter fallback cache

### DIFF
--- a/src/services/StackbyService.ts
+++ b/src/services/StackbyService.ts
@@ -10,13 +10,13 @@ import {
 	type StackbyFilter,
 	StackbyStandardFilter,
 } from "../utils/stackby-filter.js";
+import { applyLocalStandardFilter } from "../utils/stackby-local-filter.js";
 
 export class StackbyService {
 	async fetchStackbyData(
 		endpoint: string,
 		filter?: StackbyFilter | null,
 	): Promise<StackbyDataResponse> {
-
 		const apiKey: string = STACKBY_SECRET_KEY || "";
 		let url: string = `${STACKBY_BASE_URL}/${endpoint}?latest=true`;
 		let filterKey = "";
@@ -34,31 +34,23 @@ export class StackbyService {
 				filterKey ? `${filterKey}` : undefined,
 			),
 			async () => {
+				let orderedData = await this.fetchAndOrderData(url, apiKey);
 
-				const response = await fetch(url, {
-					headers: {
-						"Content-Type": "application/json",
-						"x-api-key": apiKey,
-					},
-					method: "GET",
-				});
+				/**
+				 * Some Stackby columns (for example category/select-like fields) can
+				 * return an empty result even when the filter is valid.
+				 * In that case we fetch the same endpoint without filter and apply
+				 * the requested standard operator locally to keep API behavior stable.
+				 */
+				if (
+					filter instanceof StackbyStandardFilter &&
+					orderedData.length === 0
+				) {
+					const fallbackUrl = `${STACKBY_BASE_URL}/${endpoint}?latest=true`;
 
-				if (!response.ok) {
-					const text = await response.text();
-					throw new Error(`Stackby API error: ${text}`);
+					const allData = await this.fetchAndOrderData(fallbackUrl, apiKey);
+					orderedData = applyLocalStandardFilter(allData, filter);
 				}
-
-				const data = await response.json();
-
-				const orderedData = data.data
-					.map((t: any) => ({
-						...t,
-						field: {
-							...t.field,
-							sequence: Number(t.field.sequence),
-						},
-					}))
-					.sort((a: any, b: any) => a.field.sequence - b.field.sequence);
 
 				return !filter || filter instanceof StackbyStandardFilter
 					? { data: orderedData }
@@ -67,6 +59,33 @@ export class StackbyService {
 		);
 
 		return result as StackbyDataResponse;
+	}
+
+	private async fetchAndOrderData(url: string, apiKey: string) {
+		const response = await fetch(url, {
+			headers: {
+				"Content-Type": "application/json",
+				"x-api-key": apiKey,
+			},
+			method: "GET",
+		});
+
+		if (!response.ok) {
+			const text = await response.text();
+			throw new Error(`Stackby API error: ${text}`);
+		}
+
+		const data = await response.json();
+
+		return data.data
+			.map((item: any) => ({
+				...item,
+				field: {
+					...item.field,
+					sequence: Number(item.field.sequence),
+				},
+			}))
+			.sort((a: any, b: any) => a.field.sequence - b.field.sequence);
 	}
 
 	calculateTotalItems(

--- a/src/services/theme/ThemeService.ts
+++ b/src/services/theme/ThemeService.ts
@@ -19,8 +19,7 @@ export class ThemeService {
 			skip,
 			take,
 		});
-
-themes.forEach(t => console.log(t.title, t.sequence));
+		
 		return {
 			data: themes,
 			meta: createPaginationMeta(total, page, take),

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,5 +1,28 @@
 import { redis } from "../lib/redis.js";
 import { CACHE_TTL, IS_CACHE_ENABLED } from "../utils/constants.js";
+import { safeJsonParse } from "../utils/safe-json.js";
+
+function parseCachedValue<T>(cached: unknown): T | null {
+	if (!cached) {
+		return null;
+	}
+
+	if (typeof cached === "object") {
+		return cached as T;
+	}
+
+	if (typeof cached !== "string") {
+		return null;
+	}
+
+	const parsed = safeJsonParse<T>(cached);
+
+	if (parsed === null) {
+		console.warn("Ignoring malformed cache entry");
+	}
+
+	return parsed;
+}
 
 export async function cacheOrFetch<T>(
 	key: string,
@@ -10,10 +33,11 @@ export async function cacheOrFetch<T>(
 			return await fetchFunction();
 		}
 
-		const cached: string | null = await redis!.get(key);
+		const cached: unknown = await redis!.get(key);
+		const parsedCache = parseCachedValue<T>(cached);
 
-		if (cached) {
-			return cached;
+		if (parsedCache !== null) {
+			return parsedCache;
 		}
 
 		const data = await fetchFunction();

--- a/src/utils/safe-json.ts
+++ b/src/utils/safe-json.ts
@@ -1,0 +1,7 @@
+export function safeJsonParse<T>(value: string): T | null {
+	try {
+		return JSON.parse(value) as T;
+	} catch {
+		return null;
+	}
+}

--- a/src/utils/stackby-local-filter.ts
+++ b/src/utils/stackby-local-filter.ts
@@ -1,0 +1,124 @@
+import {
+	STACKBY_FILTER_OPERATORS,
+	StackbyStandardFilter,
+} from "./stackby-filter.js";
+
+type LocalEvaluator = (
+	fieldValue: unknown,
+	normalizedField: string,
+	normalizedFilter: string,
+) => boolean;
+
+export function applyLocalStandardFilter(
+	data: any[],
+	filter: StackbyStandardFilter,
+) {
+	const column = filter.column;
+	const filterValue = filter.value;
+	const anyOfValues =
+		filter.operator === STACKBY_FILTER_OPERATORS.IS_ANY_OF
+			? parseList(filterValue)
+			: [];
+	const evaluate = getLocalFilterEvaluator(
+		filter.operator,
+		filterValue,
+		anyOfValues,
+	);
+
+	return data.filter((item) => {
+		const fieldValue = item?.field?.[column];
+		const normalizedField = normalizeValue(fieldValue);
+		const normalizedFilter = normalizeValue(filterValue);
+
+		return evaluate(fieldValue, normalizedField, normalizedFilter);
+	});
+}
+
+function getLocalFilterEvaluator(
+	operator: STACKBY_FILTER_OPERATORS,
+	filterValue: unknown,
+	anyOfValues: string[],
+): LocalEvaluator {
+	const evaluators: Partial<Record<STACKBY_FILTER_OPERATORS, LocalEvaluator>> = {
+		[STACKBY_FILTER_OPERATORS.TO_CONTAINS]: (
+			_fieldValue,
+			normalizedField,
+			normalizedFilter,
+		) => normalizedField.includes(normalizedFilter),
+		[STACKBY_FILTER_OPERATORS.DOES_NOT_CONTAIN]: (
+			_fieldValue,
+			normalizedField,
+			normalizedFilter,
+		) => !normalizedField.includes(normalizedFilter),
+		[STACKBY_FILTER_OPERATORS.EQUAL]: (
+			_fieldValue,
+			normalizedField,
+			normalizedFilter,
+		) => normalizedField === normalizedFilter,
+		[STACKBY_FILTER_OPERATORS.IS_EXACTLY]: (
+			_fieldValue,
+			normalizedField,
+			normalizedFilter,
+		) => normalizedField === normalizedFilter,
+		[STACKBY_FILTER_OPERATORS.NOT_EQUAL]: (
+			_fieldValue,
+			normalizedField,
+			normalizedFilter,
+		) => normalizedField !== normalizedFilter,
+		[STACKBY_FILTER_OPERATORS.IS_EMPTY]: (
+			_fieldValue,
+			normalizedField,
+		) => normalizedField.length === 0,
+		[STACKBY_FILTER_OPERATORS.IS_NOT_EMPTY]: (
+			_fieldValue,
+			normalizedField,
+		) => normalizedField.length > 0,
+		[STACKBY_FILTER_OPERATORS.GREATER_THAN]: (fieldValue) =>
+			toNumber(fieldValue) > toNumber(filterValue),
+		[STACKBY_FILTER_OPERATORS.GREATER_THAN_EQUAL]: (fieldValue) =>
+			toNumber(fieldValue) >= toNumber(filterValue),
+		[STACKBY_FILTER_OPERATORS.LESS_THAN]: (fieldValue) =>
+			toNumber(fieldValue) < toNumber(filterValue),
+		[STACKBY_FILTER_OPERATORS.LESS_THAN_EQUAL]: (fieldValue) =>
+			toNumber(fieldValue) <= toNumber(filterValue),
+		[STACKBY_FILTER_OPERATORS.IS_ANY_OF]: (
+			_fieldValue,
+			normalizedField,
+		) => anyOfValues.includes(normalizedField),
+	};
+
+	return evaluators[operator] ?? (() => true);
+}
+
+function normalizeValue(value: unknown): string {
+	if (value === null || value === undefined) {
+		return "";
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((entry) => normalizeValue(entry)).join(",");
+	}
+
+	return String(value).trim().toLowerCase();
+}
+
+function parseList(value: unknown): string[] {
+	if (!value) {
+		return [];
+	}
+
+	const raw = String(value).trim();
+	const listContent =
+		raw.startsWith("[") && raw.endsWith("]") ? raw.slice(1, -1) : raw;
+
+	return listContent
+		.split(",")
+		.map((entry) => entry.trim().replace(/^['\"]|['\"]$/g, ""))
+		.map((entry) => normalizeValue(entry))
+		.filter(Boolean);
+}
+
+function toNumber(value: unknown): number {
+	const parsed = Number(value);
+	return Number.isNaN(parsed) ? Number.NaN : parsed;
+}


### PR DESCRIPTION
## Contexto
A API de Stackby retornava dados corretamente sem filtro, mas alguns filtros (principalmente em `category`) vinham vazios mesmo com valores válidos.  
Também havia inconsistência no cache Redis, que podia mascarar resultados entre filtros e gerar erro de parse em entradas legadas.

## O que foi feito
- Adicionado fallback local no `StackbyService`:
  - quando o Stackby retorna vazio com filtro padrão, a API busca sem filtro e aplica o operador localmente.
- Melhorada leitura de cache:
  - entradas inválidas/legadas não quebram a request.
- Refatoração para manutenção:
  - extração da lógica de filtro local para stackby-local-filter.ts;
  - extração de parse seguro para safe-json.ts;
  - simplificação do `StackbyService` e do cache.ts.
- Remoção de logs temporários de depuração.

## Impacto
- Filtros por `category` passam a retornar dados corretamente via fallback.
- Código mais modular, legível e fácil de manter.

## Como validar
- Sem filtro:  
  `GET /stackby/Themes`
- Filtro que antes falhava:  
  `GET /stackby/Themes?operator=equal&column=category&value=Nivelamento`
- Filtro textual de controle:  
  `GET /stackby/Themes?operator=toContains&column=title&value=TypeScript`
- Confirmar ausência de erro de parse no cache durante as chamadas.

## Observações
- O fallback local só é aplicado quando a resposta filtrada do Stackby vem vazia para `StackbyStandardFilter`.
- Quando o filtro remoto funciona, o comportamento permanece inalterado.