### PR TITLE
fix: ajusta tratamento de erros para criacao de topicos @NETONoHands …

### DIFF
--- a/src/controllers/exercise/ExerciseController.ts
+++ b/src/controllers/exercise/ExerciseController.ts
@@ -1,13 +1,14 @@
-import { plainToInstance } from 'class-transformer';
-import { ValidationError, validateOrReject } from 'class-validator';
-import type { Request, Response } from 'express';
-import { GetExerciseByIdDTO } from '../../dtos/GetExerciseById.dto.js';
-import { GetExercisesByTopicIdDTO } from '../../dtos/GetExercisesByTopicId.dto.js';
-import { CreateExerciseDTO } from '../../dtos/CreateExercise.dto.js';
-import { UpdateExerciseDTO } from '../../dtos/UpdateExercise.dto.js';
-import { ExerciseService } from '../../services/exercise/ExerciseService.js';
-import { STATUS_CODE } from '../../utils/constants.js';
-import { getPaginationParams } from '../../utils/pagination.js';
+import { plainToInstance } from "class-transformer";
+import { ValidationError, validateOrReject } from "class-validator";
+import type { Request, Response } from "express";
+import { GetExerciseByIdDTO } from "../../dtos/GetExerciseById.dto.js";
+import { GetExercisesByTopicIdDTO } from "../../dtos/GetExercisesByTopicId.dto.js";
+import { CreateExerciseDTO } from "../../dtos/CreateExercise.dto.js";
+import { UpdateExerciseDTO } from "../../dtos/UpdateExercise.dto.js";
+import { ExerciseService } from "../../services/exercise/ExerciseService.js";
+import { STATUS_CODE } from "../../utils/constants.js";
+import { getPaginationParams } from "../../utils/pagination.js";
+import { NotFoundError } from "../../errors/HttpErrors.js";
 
 export class ExerciseController {
 	private exerciseService: ExerciseService;
@@ -24,7 +25,7 @@ export class ExerciseController {
 		} catch (_error) {
 			return res
 				.status(STATUS_CODE.INTERNAL_SERVER_ERROR)
-				.json({ message: 'Error fetching exercises' });
+				.json({ message: "Error fetching exercises" });
 		}
 	}
 
@@ -40,7 +41,7 @@ export class ExerciseController {
 			if (!exercise) {
 				return res
 					.status(STATUS_CODE.NOT_FOUND)
-					.json({ message: 'Exercise not found' });
+					.json({ message: "Exercise not found" });
 			}
 
 			return res.status(STATUS_CODE.OK).json(exercise);
@@ -51,11 +52,11 @@ export class ExerciseController {
 			) {
 				return res
 					.status(STATUS_CODE.BAD_REQUEST)
-					.json({ message: 'Invalid Exercise ID' });
+					.json({ message: "Invalid Exercise ID" });
 			}
 			return res
 				.status(STATUS_CODE.INTERNAL_SERVER_ERROR)
-				.json({ message: 'Error fetching exercise' });
+				.json({ message: "Error fetching exercise" });
 		}
 	}
 
@@ -77,11 +78,11 @@ export class ExerciseController {
 			) {
 				return res
 					.status(STATUS_CODE.BAD_REQUEST)
-					.json({ message: 'Invalid Topic ID' });
+					.json({ message: "Invalid Topic ID" });
 			}
 			return res
 				.status(STATUS_CODE.INTERNAL_SERVER_ERROR)
-				.json({ message: 'Error fetching exercises by topic ID' });
+				.json({ message: "Error fetching exercises by topic ID" });
 		}
 	}
 
@@ -97,17 +98,24 @@ export class ExerciseController {
 
 			return res.status(STATUS_CODE.CREATED).json(exercise);
 		} catch (error: any) {
+
 			if (
 				Array.isArray(error) &&
 				error.every((err) => err instanceof ValidationError)
 			) {
 				return res.status(STATUS_CODE.BAD_REQUEST).json({
-					message: error[0].constraints?.isNotEmpty || 'Invalid data',
+					message: error[0].constraints?.isNotEmpty || "Invalid data",
+				});
+			}
+
+			if (error instanceof NotFoundError) {
+				return res.status(error.statusCode).json({
+					message: error.message,
 				});
 			}
 
 			return res.status(STATUS_CODE.INTERNAL_SERVER_ERROR).json({
-				message: 'Error creating exercise',
+				message: "Error creating exercise",
 				details: error,
 			});
 		}
@@ -132,12 +140,12 @@ export class ExerciseController {
 				error.every((err) => err instanceof ValidationError)
 			) {
 				return res.status(STATUS_CODE.BAD_REQUEST).json({
-					message: 'Invalid data for update',
+					message: "Invalid data for update",
 				});
 			}
 
 			return res.status(STATUS_CODE.INTERNAL_SERVER_ERROR).json({
-				message: 'Error updating exercise',
+				message: "Error updating exercise",
 				details: error,
 			});
 		}
@@ -152,7 +160,7 @@ export class ExerciseController {
 		} catch (error: any) {
 			return res
 				.status(STATUS_CODE.INTERNAL_SERVER_ERROR)
-				.json({ message: 'Error deleting exercise', details: error });
+				.json({ message: "Error deleting exercise", details: error });
 		}
 	}
 }

--- a/src/controllers/exercise/ExerciseController.ts
+++ b/src/controllers/exercise/ExerciseController.ts
@@ -104,7 +104,7 @@ export class ExerciseController {
 				error.every((err) => err instanceof ValidationError)
 			) {
 				return res.status(STATUS_CODE.BAD_REQUEST).json({
-					message: error[0].constraints?.isNotEmpty || "Invalid data",
+					message: error,
 				});
 			}
 
@@ -140,7 +140,7 @@ export class ExerciseController {
 				error.every((err) => err instanceof ValidationError)
 			) {
 				return res.status(STATUS_CODE.BAD_REQUEST).json({
-					message: "Invalid data for update",
+					message: error,
 				});
 			}
 

--- a/src/controllers/exercise/ExerciseController.ts
+++ b/src/controllers/exercise/ExerciseController.ts
@@ -92,7 +92,10 @@ export class ExerciseController {
 		});
 
 		try {
-			await validateOrReject(dto);
+			await validateOrReject(dto, {
+				whitelist: true,
+				forbidNonWhitelisted: true
+			});
 
 			const exercise = await this.exerciseService.createExercise(dto);
 
@@ -131,7 +134,10 @@ export class ExerciseController {
 		});
 
 		try {
-			await validateOrReject(dto);
+			await validateOrReject(dto, {
+				whitelist: true,
+				forbidNonWhitelisted: true
+			});
 
 			const exercise = await this.exerciseService.updateExercise(id, dto);
 

--- a/src/controllers/exercise/ExerciseController.ts
+++ b/src/controllers/exercise/ExerciseController.ts
@@ -109,8 +109,10 @@ export class ExerciseController {
 			}
 
 			if (error instanceof NotFoundError) {
-				return res.status(error.statusCode).json({
-					message: error.message,
+				const message = 'Tópico inválido: não existe esse tópico';
+				return res.status(STATUS_CODE.BAD_REQUEST).json({
+					message,
+					error: message,
 				});
 			}
 

--- a/src/controllers/topic/TopicController.ts
+++ b/src/controllers/topic/TopicController.ts
@@ -20,7 +20,7 @@ export class TopicController {
 		const dto = plainToInstance(CreateTopicDTO, req.body, {
 			enableImplicitConversion: true,
 		});
-
+		
 		try {
 			await validateOrReject(dto);
 
@@ -28,21 +28,20 @@ export class TopicController {
 
 			return res.status(STATUS_CODE.CREATED).json(topic);
 		} catch (error: any) {
+			
 			if (
 				Array.isArray(error) &&
 				error.every((err) => err instanceof ValidationError)
 			) {
 				return res.status(STATUS_CODE.BAD_REQUEST).json({
-					message: error[0].constraints?.isNotEmpty || 'Invalid data',
+					message: error,
 				});
 			}
 
-			return res.status(STATUS_CODE.INTERNAL_SERVER_ERROR).json({
-				message: 'Error creating topic',
-				details: error,
-			});
+			return res.status(STATUS_CODE.INTERNAL_SERVER_ERROR).json(error);
 		}
 	}
+
 
 	async getAllTopics(req: Request, res: Response) {
 		try {

--- a/src/controllers/topic/TopicController.ts
+++ b/src/controllers/topic/TopicController.ts
@@ -22,7 +22,7 @@ export class TopicController {
 		});
 
 		try {
-			await validateOrReject(dto);
+			await validateOrReject(dto, {whitelist: true, forbidNonWhitelisted: true});
 
 			const topic = await this.topicService.createTopic(dto);
 
@@ -119,7 +119,10 @@ export class TopicController {
 		});
 
 		try {
-			await validateOrReject(dto);
+			await validateOrReject(dto, {
+				whitelist: true,
+				forbidNonWhitelisted: true
+			});
 
 			const topic = await this.topicService.updateTopic(id, dto);
 

--- a/src/controllers/topic/TopicController.ts
+++ b/src/controllers/topic/TopicController.ts
@@ -130,28 +130,30 @@ export class TopicController {
 				error.every((err) => err instanceof ValidationError)
 			) {
 				return res.status(STATUS_CODE.BAD_REQUEST).json({
-					message: 'Invalid data for update',
+					message: error,
 				});
 			}
 
 			return res.status(STATUS_CODE.INTERNAL_SERVER_ERROR).json({
-				message: 'Error updating topic',
-				details: error,
+				message: 'Internal server error',
 			});
 		}
 	}
 
 	async deleteTopic(req: Request, res: Response) {
 		const id = req.params.id.trim();
+
 		try {
 			await this.topicService.deleteTopic(id);
+
 			return res
 				.status(STATUS_CODE.OK)
 				.json({ message: 'Topic deleted with success' });
+
 		} catch (error: any) {
 			return res
 				.status(STATUS_CODE.INTERNAL_SERVER_ERROR)
-				.json({ message: 'Error deleting topic', details: error });
+				.json({ message: 'Internal server error' });
 		}
 	}
 }

--- a/src/controllers/topic/TopicController.ts
+++ b/src/controllers/topic/TopicController.ts
@@ -135,7 +135,7 @@ export class TopicController {
 			}
 
 			return res.status(STATUS_CODE.INTERNAL_SERVER_ERROR).json({
-				message: 'Internal server error',
+				message: error,
 			});
 		}
 	}

--- a/src/controllers/topic/TopicController.ts
+++ b/src/controllers/topic/TopicController.ts
@@ -20,7 +20,7 @@ export class TopicController {
 		const dto = plainToInstance(CreateTopicDTO, req.body, {
 			enableImplicitConversion: true,
 		});
-		
+
 		try {
 			await validateOrReject(dto);
 
@@ -28,7 +28,7 @@ export class TopicController {
 
 			return res.status(STATUS_CODE.CREATED).json(topic);
 		} catch (error: any) {
-			
+
 			if (
 				Array.isArray(error) &&
 				error.every((err) => err instanceof ValidationError)
@@ -140,10 +140,12 @@ export class TopicController {
 		}
 	}
 
+
 	async deleteTopic(req: Request, res: Response) {
 		const id = req.params.id.trim();
 
 		try {
+
 			await this.topicService.deleteTopic(id);
 
 			return res
@@ -151,9 +153,10 @@ export class TopicController {
 				.json({ message: 'Topic deleted with success' });
 
 		} catch (error: any) {
+			
 			return res
 				.status(STATUS_CODE.INTERNAL_SERVER_ERROR)
-				.json({ message: 'Internal server error' });
+				.json({ message: 'Error deleting topic', details: error });
 		}
 	}
 }

--- a/src/controllers/topic/TopicController.ts
+++ b/src/controllers/topic/TopicController.ts
@@ -8,6 +8,7 @@ import { STATUS_CODE } from '../../utils/constants.js';
 import { CreateTopicDTO } from '../../dtos/CreateTopic.dto.js';
 import { UpdateTopicDTO } from '../../dtos/UpdateTopic.dto.js';
 import { getPaginationParams } from '../../utils/pagination.js';
+import { NotFoundError } from "../../errors/HttpErrors.js";
 
 export class TopicController {
 	private topicService: TopicService;
@@ -22,7 +23,7 @@ export class TopicController {
 		});
 
 		try {
-			await validateOrReject(dto, {whitelist: true, forbidNonWhitelisted: true});
+			await validateOrReject(dto, { whitelist: true, forbidNonWhitelisted: true });
 
 			const topic = await this.topicService.createTopic(dto);
 
@@ -35,6 +36,14 @@ export class TopicController {
 			) {
 				return res.status(STATUS_CODE.BAD_REQUEST).json({
 					message: error,
+				});
+			}
+
+			if (error instanceof NotFoundError) {
+				const message = 'Tema inválido: não existe esse tema';
+				return res.status(STATUS_CODE.BAD_REQUEST).json({
+					message,
+					error: message,
 				});
 			}
 
@@ -156,7 +165,7 @@ export class TopicController {
 				.json({ message: 'Topic deleted with success' });
 
 		} catch (error: any) {
-			
+
 			return res
 				.status(STATUS_CODE.INTERNAL_SERVER_ERROR)
 				.json({ message: 'Error deleting topic', details: error });

--- a/src/dtos/CreateTopic.dto.ts
+++ b/src/dtos/CreateTopic.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsOptional, IsString } from "class-validator";
+import { IsNotEmpty, IsNumber, IsString } from "class-validator";
 
 export class CreateTopicDTO {
 	@IsString()
@@ -15,6 +15,12 @@ export class CreateTopicDTO {
 	references!: string;
 	
 	@IsString()
-	@IsOptional()
-	themeId?: string;
+	@IsNotEmpty()
+	themeId!: string;
+
+	@IsNumber()
+	sequence!: number;
+
+	@IsString()
+	videoUrl!: string;
 }

--- a/src/services/exercise/ExerciseService.ts
+++ b/src/services/exercise/ExerciseService.ts
@@ -1,6 +1,7 @@
 import prisma from '../../../client.js';
 import { CreateExerciseDTO } from '../../dtos/CreateExercise.dto.js';
 import { UpdateExerciseDTO } from '../../dtos/UpdateExercise.dto.js';
+import { BadRequestError, NotFoundError } from '../../errors/HttpErrors.js';
 import { createPaginationMeta, pagination } from '../../utils/pagination.js';
 
 export class ExerciseService {
@@ -25,6 +26,15 @@ export class ExerciseService {
 	}
 
 	async createExercise(dto: CreateExerciseDTO) {
+
+		const topicExists = await prisma.topic.findUnique({
+			where: { id: dto.topicId },
+		});
+
+		if (dto.topicId && !topicExists) {
+			throw new NotFoundError('Topic not found');
+		}
+
 		const exercise = await prisma.exercise.create({
 			data: {
 				title: dto.title,

--- a/src/services/topic/TopicService.ts
+++ b/src/services/topic/TopicService.ts
@@ -2,9 +2,18 @@ import prisma from '../../../client.js';
 import { CreateTopicDTO } from '../../dtos/CreateTopic.dto.js';
 import { UpdateTopicDTO } from '../../dtos/UpdateTopic.dto.js';
 import { createPaginationMeta, pagination } from '../../utils/pagination.js';
+import { NotFoundError } from '../../errors/HttpErrors.js';
 
 export class TopicService {
 	async createTopic(dto: CreateTopicDTO) {
+
+		const themeExists = await prisma.theme.findUnique({
+			where: { id: dto.themeId },
+		});
+
+		if (dto.themeId && !themeExists) {
+			throw new NotFoundError('Theme not found');
+		}
 		const topic = await prisma.topic.create({
 			data: {
 				title: dto.title,


### PR DESCRIPTION
…refs ## 89

#89  - [MVP3] fix: tratamento de erros na criação de tópicos
====
  
### 🆙 CHANGELOG

- Ajusta código para tratamento de erros ao criar um tópico.

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas

## ⚠️ Como testar:

- [ ] Entrar na branch main e dar um `git pull`
- [ ] Entrar na branch `89-mvp3-fix-tratamento-de-erros-na-criacao-de-topicos`
- [ ] Rodar o `npm run dev`
- [ ] Copiar a URL `http://localhost:5002` e colar no Postman ou ThunderClient
- [ ] Adicionar a extensão `/topics`
- [ ] Preencher os campos de criação de acordo com om schema de topics
- [ ] Criar o tópico com os campos obrigatórios
- [ ] Deve retornar 201 e o tópico criado para caso de sucesso
- [ ] Deve retornar 401 para usuário não logado
- [ ] Deve retornar 403 para usuário logado, mas não autorizado
- [ ] Deve retornar 400 para tópico não criado
- [ ] Deve retornar 500 para erro de servidor
