### PR TITLE
feat: Implementado UserController and adicionado endpoint para recuperar o cargo. @andrea-leite

### DIFF
--- a/src/controllers/user/UserController.ts
+++ b/src/controllers/user/UserController.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from 'express';
 import { UserService } from '../../services/UserService.js';
+import { NotFoundError } from '../../errors/HttpErrors.js';
 
 
 export class UserController {
@@ -16,13 +17,17 @@ export class UserController {
             return res.status(400).json({ message: 'Email header is required and must be a string' });
         }
 
-        const user = await this.userService.findUserByEmail(email);
+        try {
+            const user = await this.userService.findUserByEmail(email);
 
-        if (!user) {
-            return res.status(404).json({ message: 'User not found' });
+            return res.status(200).json({ role: user.role });
+        } catch (error) {
+            if (error instanceof NotFoundError) {
+                return res.status(404).json(error);
+            }
+
+            return res.status(500).json('Internal server error.')
         }
-
-        return res.status(200).json({ role: user.role });
     }
 }
 

--- a/src/controllers/user/UserController.ts
+++ b/src/controllers/user/UserController.ts
@@ -1,0 +1,29 @@
+import type { Request, Response } from 'express';
+import { UserService } from '../../services/UserService.js';
+
+
+export class UserController {
+
+    private userService: UserService;
+
+    constructor() {
+        this.userService = new UserService();
+    }
+    async getUserRole(req: Request, res: Response) {
+        const email = req.headers.email;
+
+        if (!email || typeof email !== 'string') {
+            return res.status(400).json({ message: 'Email header is required and must be a string' });
+        }
+
+        const user = await this.userService.findUserByEmail(email);
+
+        if (!user) {
+            return res.status(404).json({ message: 'User not found' });
+        }
+
+        return res.status(200).json({ role: user.role });
+    }
+}
+
+export default UserController;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -8,6 +8,7 @@ import { Flagsmith } from 'flagsmith-nodejs';
 import { ThemeController } from '../controllers/theme/ThemeController.js';
 import { TopicController } from '../controllers/topic/TopicController.js';
 import { ExerciseController } from '../controllers/exercise/ExerciseController.js';
+import { UserController } from '../controllers/user/UserController.js';
 
 if (!process.env.FLAGSMITH_SERVER_KEY) {
 	throw new Error(
@@ -62,8 +63,12 @@ router.get('/stackby/:endpoint', (req, res, next) =>
 	new StackbyController().getStackbyData(req, res, next),
 );
 
+router.get('/user/role', (req, res) => {
+	new UserController().getUserRole(req, res);
+});
 
 router.use(validateTokenMiddleware);
+
 
 router.get('/status/:id/:idType', (req, res) =>
 	new ProgressController().getTopicExercisesStatusProgress(req, res),

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,12 +1,12 @@
 import prisma from "../../client.js";
+import { NotFoundError } from "../errors/HttpErrors.js";
 
 export class UserService {
-	async findUserByEmail(email: string) {
-		try {
-			const user = await prisma.user.findUnique({ where: { email } });
-			return user ?? null;
-		} catch (error) {
-			throw new Error("Error fetching user from database");
-		}
-	}
+    async findUserByEmail(email: string) {
+            const user = await prisma.user.findUnique({ where: { email } });
+
+            if (!user) throw new NotFoundError("User not found.");
+
+            return user;
+    }
 }

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -4,8 +4,7 @@ export class UserService {
 	async findUserByEmail(email: string) {
 		try {
 			const user = await prisma.user.findUnique({ where: { email } });
-			if (!user) throw new Error("User not found.");
-			return user;
+			return user ?? null;
 		} catch (error) {
 			throw new Error("Error fetching user from database");
 		}


### PR DESCRIPTION
#81 Implementado UserController and adicionado endpoint para recuperar o cargo. @andrea-leite

  
### 🆙 CHANGELOG

*Esses passos são apenas exemplos*

- Adicionado `UserController.getUserRole` para ler o header `email`, buscar o usuário e retornar o `role` em JSON.
- Registrada a rota `GET /user/role` no router para permitir que o frontend consulte o cargo do usuário no backend.

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

*Esses passos são apenas exemplos*

- [ ] Rodar o backend localmente
- [ ] Fazer nova chamada com ThunderClient/Postman para a url (http://localhost:5002/user/role)
- [ ] enviar email no header
- [ ] email válido: retorna 200 e o role atribuído ao email
- [ ] email inválido: retorna 404
- [ ] sem email retorna 400
