### PR TITLE
fix: ajusta mensagem para topico nao enviado

### DIFF
--- a/src/controllers/exercise/ExerciseController.ts
+++ b/src/controllers/exercise/ExerciseController.ts
@@ -8,7 +8,7 @@ import { UpdateExerciseDTO } from "../../dtos/UpdateExercise.dto.js";
 import { ExerciseService } from "../../services/exercise/ExerciseService.js";
 import { STATUS_CODE } from "../../utils/constants.js";
 import { getPaginationParams } from "../../utils/pagination.js";
-import { NotFoundError } from "../../errors/HttpErrors.js";
+import { BadRequestError, NotFoundError } from "../../errors/HttpErrors.js";
 
 export class ExerciseController {
 	private exerciseService: ExerciseService;
@@ -108,6 +108,13 @@ export class ExerciseController {
 			) {
 				return res.status(STATUS_CODE.BAD_REQUEST).json({
 					message: error,
+				});
+			}
+
+			if (error instanceof BadRequestError) {
+				return res.status(STATUS_CODE.BAD_REQUEST).json({
+					message: error.message,
+					error: error.message,
 				});
 			}
 

--- a/src/dtos/CreateExercise.dto.ts
+++ b/src/dtos/CreateExercise.dto.ts
@@ -17,7 +17,6 @@ export class CreateExerciseDTO {
   @IsInt()
   sequence?: number;
 
-  @IsOptional()
   @IsNotEmpty({ message: "Topic ID is required" })
   topicId?: string;
 }

--- a/src/dtos/CreateExercise.dto.ts
+++ b/src/dtos/CreateExercise.dto.ts
@@ -18,6 +18,6 @@ export class CreateExerciseDTO {
   sequence?: number;
 
   @IsOptional()
-  @IsString()
+  @IsNotEmpty({ message: "Topic ID is required" })
   topicId?: string;
 }

--- a/src/dtos/CreateExercise.dto.ts
+++ b/src/dtos/CreateExercise.dto.ts
@@ -17,6 +17,7 @@ export class CreateExerciseDTO {
   @IsInt()
   sequence?: number;
 
+  @IsString()
   @IsNotEmpty({ message: "Topic ID is required" })
   topicId?: string;
 }

--- a/src/dtos/CreateTopic.dto.ts
+++ b/src/dtos/CreateTopic.dto.ts
@@ -2,25 +2,29 @@ import { IsNotEmpty, IsNumber, IsString } from "class-validator";
 
 export class CreateTopicDTO {
 	@IsString()
-	@IsNotEmpty()
+	@IsNotEmpty({ message: "Title is required" })
 	title!: string;
 
 	@IsString()
+	@IsNotEmpty({ message: "Description is required" })
 	description!: string;
 
 	@IsString()
+	@IsNotEmpty({ message: "Short description is required" })
 	shortDescription!: string;
 
 	@IsString()
 	references!: string;
 	
 	@IsString()
-	@IsNotEmpty()
+	@IsNotEmpty({ message: "Theme ID is required" })
 	themeId!: string;
 
 	@IsNumber()
+	@IsNotEmpty({ message: "Sequence is required" })
 	sequence!: number;
 
 	@IsString()
+	@IsNotEmpty({ message: "Video URL is required" })
 	videoUrl!: string;
 }

--- a/src/services/exercise/ExerciseService.ts
+++ b/src/services/exercise/ExerciseService.ts
@@ -27,6 +27,10 @@ export class ExerciseService {
 
 	async createExercise(dto: CreateExerciseDTO) {
 
+		if (!dto.topicId) {
+			throw new BadRequestError("Tópico obrigatório");
+		}
+
 		const topicExists = await prisma.topic.findUnique({
 			where: { id: dto.topicId },
 		});


### PR DESCRIPTION
#100 - [MVP3] - Corrigir tratamento de erro na criação de exercício sem tópico
====
  
### 🆙 CHANGELOG

*Esses passos são apenas exemplos*

- Alteração no dto de exercício para validar a obrigatoriedade do tópico
- Tratamento de erro no create do service
- Tratamento de erro no create do controller

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas

## ⚠️ Como testar:


- [ ] Rodar o backend da aplicação
- [ ] Testar a  URL `http://localhost:5002/exercises` no Postman, Insomnia ou outra aplicação
- [ ] Criar um exercício sem mandar o tópico no body da requisição
- [ ] Verificar as mensagens de erro retornadas

