### PR TITLE
fix: include theme in exercise listing response

### DIFF
--- a/src/services/exercise/ExerciseService.ts
+++ b/src/services/exercise/ExerciseService.ts
@@ -10,7 +10,11 @@ export class ExerciseService {
 		const total = await prisma.exercise.count();
 		const exercises = await prisma.exercise.findMany({
 			include: {
-				topic: true,
+				topic: {
+					include: {
+						theme: true,
+					},
+				},
 			},
 			orderBy: {
 				sequence: 'asc',
@@ -18,6 +22,7 @@ export class ExerciseService {
 			skip,
 			take,
 		});
+
 		return {
 			data: exercises,
 			meta: createPaginationMeta(total, page, take),
@@ -34,7 +39,13 @@ export class ExerciseService {
 				topicId: dto.topicId || null,
 				isActive: true,
 			},
-			include: { topic: true },
+			include: {
+				topic: {
+					include: {
+						theme: true,
+					},
+				},
+			},
 		});
 
 		return exercise;
@@ -42,6 +53,7 @@ export class ExerciseService {
 
 	async updateExercise(id: string, dto: UpdateExerciseDTO) {
 		const existing = await prisma.exercise.findUnique({ where: { id } });
+
 		if (!existing) {
 			throw new Error('Exercise not found');
 		}
@@ -51,7 +63,13 @@ export class ExerciseService {
 			data: {
 				...dto,
 			},
-			include: { topic: true },
+			include: {
+				topic: {
+					include: {
+						theme: true,
+					},
+				},
+			},
 		});
 
 		return updated;
@@ -65,7 +83,11 @@ export class ExerciseService {
 	async getExerciseById(id: string) {
 		return await prisma.exercise.findUnique({
 			include: {
-				topic: true,
+				topic: {
+					include: {
+						theme: true,
+					},
+				},
 			},
 			where: { id },
 		});


### PR DESCRIPTION
#<NUMERO-DO-CARD> - Exibir tema relacionado na listagem de exercícios

====

### 🆙 CHANGELOG

- Ajustada a consulta da listagem de exercícios para incluir o tema relacionado ao tópico.
- Padronizado o retorno da API para criação, atualização e busca de exercícios, incluindo os dados de tema.
- Mantida a compatibilidade com a paginação e com os fluxos existentes de visualização e edição.

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] Fazer deploy em ambiente de teste
- [x] Abrir a tela de CMS > Exercícios
- [x] Verificar se a coluna **Tópico** é exibida corretamente
- [x] Verificar se a coluna **Tema** é exibida corretamente
- [x] Validar que a paginação continua funcionando normalmente
- [x] Validar que os fluxos de visualização e edição permanecem funcionando
- [x] Alteração proposta no card foi implementada