### PR TITLE
fix: adiciona ordenacao para a lista de tópicos @Peu-Wan

### DIFF
--- a/src/controllers/topic/TopicController.ts
+++ b/src/controllers/topic/TopicController.ts
@@ -7,8 +7,8 @@ import { TopicService } from '../../services/topic/TopicService.js';
 import { STATUS_CODE } from '../../utils/constants.js';
 import { CreateTopicDTO } from '../../dtos/CreateTopic.dto.js';
 import { UpdateTopicDTO } from '../../dtos/UpdateTopic.dto.js';
-import { getPaginationParams } from '../../utils/pagination.js';
-import { NotFoundError } from "../../errors/HttpErrors.js";
+import { getPaginationParams, getSortParams } from '../../utils/pagination.js';
+import { NotFoundError } from '../../errors/HttpErrors.js';
 
 export class TopicController {
 	private topicService: TopicService;
@@ -55,7 +55,8 @@ export class TopicController {
 	async getAllTopics(req: Request, res: Response) {
 		try {
 			const { page, limit } = getPaginationParams(req);
-			const topics = await this.topicService.getAllTopics(page, limit);
+			const { sortBy, sortOrder } = getSortParams(req);
+			const topics = await this.topicService.getAllTopics(page, limit, sortBy, sortOrder);
 			return res.status(STATUS_CODE.OK).json(topics);
 		} catch (_error) {
 			return res

--- a/src/services/topic/TopicService.ts
+++ b/src/services/topic/TopicService.ts
@@ -27,8 +27,17 @@ export class TopicService {
 		return topic;
 	}
 
-	async getAllTopics(page: number = 1, limit: number = 10) {
+	async getAllTopics(page: number = 1, limit: number = 10, sortBy?: string, sortOrder: 'asc' | 'desc' = 'asc') {
 		const { skip, take } = pagination(page, limit);
+
+		const fieldMapping: Record<string, any> = {
+			id: { id: sortOrder },
+			title: { title: sortOrder },
+			shortDescription: { shortDescription: sortOrder },
+			themeId: { themeId: sortOrder },
+		};
+
+		const orderBy = sortBy && fieldMapping[sortBy] ? fieldMapping[sortBy] : undefined;
 
 		const total = await prisma.topic.count();
 		const topics = await prisma.topic.findMany({
@@ -39,6 +48,7 @@ export class TopicService {
 			},
 			skip,
 			take,
+			...(orderBy && { orderBy }),
 		});
 
 		return {

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -24,5 +24,15 @@ export function getPaginationParams (req: Request) {
 return { page, limit };
 }
 
+const ALLOWED_SORT_FIELDS = ['id', 'title', 'shortDescription'];
+const ALLOWED_SORT_ORDERS = ['asc', 'desc'];
 
+export function getSortParams(req: Request) {
+    const sortByRaw = (req.query.sortBy as string) || '';
+    const sortOrderRaw = (req.query.sortOrder as string) || 'asc';
 
+    const sortBy = ALLOWED_SORT_FIELDS.includes(sortByRaw) ? sortByRaw : undefined;
+    const sortOrder = ALLOWED_SORT_ORDERS.includes(sortOrderRaw) ? sortOrderRaw as 'asc' | 'desc' : 'asc';
+
+    return { sortBy, sortOrder };
+}


### PR DESCRIPTION
#91 - 
fix: admin: topicos: ordenamento deve ser para toda a lista (não somente para a página)
====
  
*Esses passos são apenas exemplos*

- Adiciona ordenação aos arquivos de tópicos

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

*Esses passos são apenas exemplos*

- [ ] Rodar o backend da aplicação
- [ ] Abrir URL `http://localhost:5002/topics?page=1&limit=10&sortBy=title&sortOrder=asc`
- [ ] Verificar  os tópicos em ordem cresecnte
- [ ] Abrir URL `http://localhost:5002/topics?page=1&limit=10&sortBy=title&sortOrder=desc`
- [ ] Verificar os tópicos em ordem decresecnte
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada
